### PR TITLE
Fix requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ timm
 h5py
 submitit
 scikit-image
-setuptools==59.4.0
+einops
+transformers


### PR DESCRIPTION
setuptools is a python base package and is therefore not required to be mentioned in `requirements.txt`. einops and transformers are dependencies which are required but not mentioned in requirements.